### PR TITLE
Exclude Graphviz dot file from test that triggers late graphiz bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dots parse-all-graphviz-dots: dotfiles.txt
 	done
 
 dotfiles.txt:
-	find graphviz -name '*.dot' > $@
+	find graphviz -name '*.dot' | grep -v "nullderefrebuildlist\.dot$$" > $@
 
 readme: readme.html
 


### PR DESCRIPTION
The new dot file was added and the bug was fixed in
https://gitlab.com/graphviz/graphviz/commit/8375908cba04be37f571abd1519b04286d3655fa

The fix is not yet included in a https://github.com/mdaines/viz.js/
release.