### PR TITLE
Change from yarn install to npm install in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: yarn install
+      - run: npm install
 
       - save_cache:
           paths:


### PR DESCRIPTION
This avoids version mismatch since versions are locked in
package-lock.json with yarn doesn't respect.

Log from yarn:

yarn install v1.9.4
info No lockfile found.
warning package-lock.json found. Your project contains lock files
generated by tools other than Yarn. It is advised not to mix package
managers in order to avoid resolution inconsistencies caused by
unsynchronized lock files. To clear this warning, remove
package-lock.json.