### PR TITLE
Fix hold-off time not being used until after reload

### DIFF
--- a/src/TextEditor.js
+++ b/src/TextEditor.js
@@ -109,6 +109,8 @@ class TextEditor extends React.Component {
     return (
       <div ref={div => this.div = div}>
         <AceEditor
+          // FIXME: Remove workaround when https://github.com/securingsincity/react-ace/issues/767 is fixed
+          key={this.props.holdOff}
           mode="dot"
           theme="github"
           fontSize={this.props.fontSize + 'px'}


### PR DESCRIPTION
Fixes https://github.com/magjac/graphviz-visual-editor/issues/128 by
adding a workaround for
https://github.com/securingsincity/react-ace/issues/767.