### PR TITLE
Correct wasm folder when serving production bundle

### DIFF
--- a/src/Graph.js
+++ b/src/Graph.js
@@ -88,7 +88,7 @@ class Graph extends React.Component {
   }
 
   createGraph() {
-    wasmFolder(process.env.PUBLIC_URL + 'wasm');
+    wasmFolder(process.env.PUBLIC_URL.replace(/\.$/, '') + 'wasm');
     this.graphviz = this.div.graphviz()
       .onerror(this.handleError.bind(this))
       .on('initEnd', () => this.renderGraph.call(this));


### PR DESCRIPTION
The PUBLIC_URL of the application in the production bundle ends with
"/.". When the was folder is added, it becomes "/.wasm" instead of the
intended "/wasm". By adding "/wasm" instead, the URL is becomes
correct.

Fixes https://github.com/magjac/graphviz-visual-editor/issues/139.