### PR TITLE
fix grid spacing after update to Mui v5.

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -808,13 +808,13 @@ class Index extends React.Component {
           />
         }
         <Grid container
-          spacing={3}
+          rowSpacing={1.5}
           style={{
             margin: 0,
             width: '100%',
           }}
         >
-          <Grid item xs={columns.textEditor}>
+          <Grid item xs={columns.textEditor} padding={1.5}>
             <Paper elevation={leftPaneElevation} className={paperClass}>
               {this.state.nodeFormatDrawerIsOpen &&
                 <FormatDrawer
@@ -860,7 +860,7 @@ class Index extends React.Component {
             </Paper>
           </Grid>
           {this.state.insertPanelsAreOpen && this.state.graphInitialized && (
-            <Grid item xs={columns.insertPanels}>
+            <Grid item xs={columns.insertPanels} padding={1.5}>
               <Paper elevation={midPaneElevation} className={paperClass}>
                 <InsertPanels
                     onClick={this.handleInsertPanelsClick}
@@ -871,7 +871,7 @@ class Index extends React.Component {
               </Paper>
             </Grid>
           )}
-          <Grid item xs={columns.graph}>
+          <Grid item xs={columns.graph} padding={1.5}>
             <Paper elevation={rightPaneElevation} className={paperClass}>
               <Graph
                 hasFocus={graphHasFocus}


### PR DESCRIPTION
In Material UI v4, half the grid spacing seems to have been applied around each grid item, giving full grid spacing only between grid items. In Mui v5, the full grid spacing seems to be applied both outside and in between grid items.

This change was introduced in
2ca5a6ab4c58927605e95740c51f2aefc0d5d932.