### PR TITLE
fix vertical placement of updated snackbar after update to Material UI v4

### DIFF
--- a/src/UpdatedSnackbar.js
+++ b/src/UpdatedSnackbar.js
@@ -13,7 +13,7 @@ import graphvizVersions from './graphviz-versions.json';
 const styles = theme => ({
   snackbar: {
     "display": "block",
-    "margin-top": "72px",
+    "margin-top": "48px",
     "max-width": "none",
     "width": "100%",
   },


### PR DESCRIPTION
This change was introduced already when updating Matgerial UI from v3 to v4 in 2975e49c2936f98455da54ade56667dff16e3a5a. The problem persisted in Mui v5.