### PR TITLE
Migrate from JSS to new default styling solution Emotion in Mui v5

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        removed_code_behavior: adjust_base

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-dom": "^17.0.2",
         "react-perfect-scrollbar": "^1.5.8",
         "react-scripts": "^5.0.1",
+        "tss-react": "^4.9.3",
         "typeface-roboto": "^1.1.13"
       },
       "devDependencies": {
@@ -27820,6 +27821,30 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
+    "node_modules/tss-react": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-4.9.3.tgz",
+      "integrity": "sha512-TqI0kBFmgW0f5YIOD2PMdHu6FnqSxVDUf5uJ7+gVkhemtMfwdlFpvXpddgSesktizr9PU9hY2nZ+kNnf0KQb9A==",
+      "dependencies": {
+        "@emotion/cache": "*",
+        "@emotion/serialize": "*",
+        "@emotion/utils": "*"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/server": "^11.4.0",
+        "@mui/material": "^5.0.0",
+        "react": "^16.8.0 || ^17.0.2 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/server": {
+          "optional": true
+        },
+        "@mui/material": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsutils": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -49963,6 +49988,16 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    },
+    "tss-react": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-4.9.3.tgz",
+      "integrity": "sha512-TqI0kBFmgW0f5YIOD2PMdHu6FnqSxVDUf5uJ7+gVkhemtMfwdlFpvXpddgSesktizr9PU9hY2nZ+kNnf0KQb9A==",
+      "requires": {
+        "@emotion/cache": "*",
+        "@emotion/serialize": "*",
+        "@emotion/utils": "*"
+      }
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@mui/codemod": "^5.14.19",
         "@mui/icons-material": "^5.14.19",
         "@mui/material": "^5.14.19",
-        "@mui/styles": "^5.14.19",
         "ace-builds": "^1.32.0",
         "d3-graphviz": "4.1.0",
         "d3-scale-chromatic": "^1.5.0",
@@ -5843,64 +5842,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
-    "node_modules/@mui/styles": {
-      "version": "5.14.19",
-      "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-5.14.19.tgz",
-      "integrity": "sha512-5yARLEJ8zPzY6zpebupK3PqDo6jQBz1s78qXnBju10toP9HT4WEydpYdm+orDAlUUxP8eVlcpK0fVwza9NwbjA==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.4",
-        "@emotion/hash": "^0.9.1",
-        "@mui/private-theming": "^5.14.19",
-        "@mui/types": "^7.2.10",
-        "@mui/utils": "^5.14.19",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
-        "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.10.0",
-        "jss-plugin-camel-case": "^10.10.0",
-        "jss-plugin-default-unit": "^10.10.0",
-        "jss-plugin-global": "^10.10.0",
-        "jss-plugin-nested": "^10.10.0",
-        "jss-plugin-props-sort": "^10.10.0",
-        "jss-plugin-rule-value-function": "^10.10.0",
-        "jss-plugin-vendor-prefixer": "^10.10.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/styles/node_modules/@emotion/hash": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
-    },
-    "node_modules/@mui/styles/node_modules/clsx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@mui/styles/node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
-    },
     "node_modules/@mui/system": {
       "version": "5.14.19",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.19.tgz",
@@ -10008,15 +9949,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/css-vendor": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
-      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.8.3",
-        "is-in-browser": "^1.0.2"
-      }
-    },
     "node_modules/css-what": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
@@ -14042,11 +13974,6 @@
         "node": ">=8.12.0"
       }
     },
-    "node_modules/hyphenate-style-name": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
-    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -14451,11 +14378,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-in-browser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
     },
     "node_modules/is-installed-globally": {
       "version": "0.4.0",
@@ -20181,93 +20103,6 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
-    },
-    "node_modules/jss": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
-      "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "csstype": "^3.0.2",
-        "is-in-browser": "^1.1.3",
-        "tiny-warning": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/jss"
-      }
-    },
-    "node_modules/jss-plugin-camel-case": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
-      "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "hyphenate-style-name": "^1.0.3",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-default-unit": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
-      "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-global": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
-      "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-nested": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
-      "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "node_modules/jss-plugin-props-sort": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
-      "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-rule-value-function": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
-      "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "node_modules/jss-plugin-vendor-prefixer": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
-      "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "css-vendor": "^2.0.8",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss/node_modules/csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
@@ -27671,11 +27506,6 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "node_modules/tinycolor2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
@@ -33572,47 +33402,6 @@
         }
       }
     },
-    "@mui/styles": {
-      "version": "5.14.19",
-      "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-5.14.19.tgz",
-      "integrity": "sha512-5yARLEJ8zPzY6zpebupK3PqDo6jQBz1s78qXnBju10toP9HT4WEydpYdm+orDAlUUxP8eVlcpK0fVwza9NwbjA==",
-      "requires": {
-        "@babel/runtime": "^7.23.4",
-        "@emotion/hash": "^0.9.1",
-        "@mui/private-theming": "^5.14.19",
-        "@mui/types": "^7.2.10",
-        "@mui/utils": "^5.14.19",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
-        "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.10.0",
-        "jss-plugin-camel-case": "^10.10.0",
-        "jss-plugin-default-unit": "^10.10.0",
-        "jss-plugin-global": "^10.10.0",
-        "jss-plugin-nested": "^10.10.0",
-        "jss-plugin-props-sort": "^10.10.0",
-        "jss-plugin-rule-value-function": "^10.10.0",
-        "jss-plugin-vendor-prefixer": "^10.10.0",
-        "prop-types": "^15.8.1"
-      },
-      "dependencies": {
-        "@emotion/hash": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-          "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
-        },
-        "clsx": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-          "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
-        },
-        "csstype": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-          "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
-        }
-      }
-    },
     "@mui/system": {
       "version": "5.14.19",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.19.tgz",
@@ -36641,15 +36430,6 @@
       "requires": {
         "mdn-data": "2.0.4",
         "source-map": "^0.6.1"
-      }
-    },
-    "css-vendor": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
-      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
-      "requires": {
-        "@babel/runtime": "^7.8.3",
-        "is-in-browser": "^1.0.2"
       }
     },
     "css-what": {
@@ -39692,11 +39472,6 @@
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
     },
-    "hyphenate-style-name": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
-    },
     "iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -39972,11 +39747,6 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
-    },
-    "is-in-browser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
     },
     "is-installed-globally": {
       "version": "0.4.0",
@@ -44454,91 +44224,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      }
-    },
-    "jss": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
-      "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "csstype": "^3.0.2",
-        "is-in-browser": "^1.1.3",
-        "tiny-warning": "^1.0.2"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-          "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
-        }
-      }
-    },
-    "jss-plugin-camel-case": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
-      "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "hyphenate-style-name": "^1.0.3",
-        "jss": "10.10.0"
-      }
-    },
-    "jss-plugin-default-unit": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
-      "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "jss-plugin-global": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
-      "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "jss-plugin-nested": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
-      "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "jss-plugin-props-sort": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
-      "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "jss-plugin-rule-value-function": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
-      "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "jss-plugin-vendor-prefixer": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
-      "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "css-vendor": "^2.0.8",
-        "jss": "10.10.0"
       }
     },
     "jsx-ast-utils": {
@@ -49867,11 +49552,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tinycolor2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@mui/codemod": "^5.14.19",
     "@mui/icons-material": "^5.14.19",
     "@mui/material": "^5.14.19",
-    "@mui/styles": "^5.14.19",
     "ace-builds": "^1.32.0",
     "d3-graphviz": "4.1.0",
     "d3-scale-chromatic": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-dom": "^17.0.2",
     "react-perfect-scrollbar": "^1.5.8",
     "react-scripts": "^5.0.1",
+    "tss-react": "^4.9.3",
     "typeface-roboto": "^1.1.13"
   },
   "scripts": {

--- a/src/AboutDialog.js
+++ b/src/AboutDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import withRoot from './withRoot';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
@@ -159,4 +159,4 @@ AboutDialog.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withRoot(withStyles(styles)(AboutDialog));
+export default withRoot(withStyles(AboutDialog, styles));

--- a/src/ButtonAppBar.js
+++ b/src/ButtonAppBar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
@@ -278,4 +278,4 @@ ButtonAppBar.propTypes = {
   onHelpButtonClick: PropTypes.func.isRequired,
 };
 
-export default withStyles(styles)(ButtonAppBar);
+export default withStyles(ButtonAppBar, styles);

--- a/src/ColorPicker.js
+++ b/src/ColorPicker.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import withRoot from './withRoot';
 import FormControl from '@mui/material/FormControl';
 import Input from '@mui/material/Input';
@@ -88,4 +88,4 @@ ColorPicker.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withRoot(withStyles(styles)(ColorPicker));
+export default withRoot(withStyles(ColorPicker, styles));

--- a/src/DoYouWantToDeleteDialog.js
+++ b/src/DoYouWantToDeleteDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import withRoot from './withRoot';
 import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
@@ -75,4 +75,4 @@ DoYouWantToDeleteDialog.propTypes = {
   onDelete: PropTypes.func.isRequired,
 };
 
-export default withRoot(withStyles(styles)(DoYouWantToDeleteDialog));
+export default withRoot(withStyles(DoYouWantToDeleteDialog, styles));

--- a/src/DoYouWantToReplaceItDialog.js
+++ b/src/DoYouWantToReplaceItDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import withRoot from './withRoot';
 import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
@@ -74,4 +74,4 @@ DoYouWantToReplaceItDialog.propTypes = {
   onReplace: PropTypes.func.isRequired,
 };
 
-export default withRoot(withStyles(styles)(DoYouWantToReplaceItDialog));
+export default withRoot(withStyles(DoYouWantToReplaceItDialog, styles));

--- a/src/DotSrcPreview.js
+++ b/src/DotSrcPreview.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import 'react-perfect-scrollbar/dist/css/styles.css';
 import PerfectScrollbar from 'react-perfect-scrollbar'
 
@@ -34,4 +34,4 @@ DotSrcPreview.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(DotSrcPreview);
+export default withStyles(DotSrcPreview, styles);

--- a/src/DotSrcPreview.js
+++ b/src/DotSrcPreview.js
@@ -7,7 +7,7 @@ import PerfectScrollbar from 'react-perfect-scrollbar'
 const styles = {
   scrollbars: {
     width: 200,
-    height: '6em',
+    height: '6em !important',
   },
   pre: {
     margin: 0,

--- a/src/ExportAsSvgDialog.js
+++ b/src/ExportAsSvgDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import withRoot from './withRoot';
 import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
@@ -116,4 +116,4 @@ ExportAsSvgDialog.propTypes = {
   onClose: PropTypes.func.isRequired,
 };
 
-export default withRoot(withStyles(styles)(ExportAsSvgDialog));
+export default withRoot(withStyles(ExportAsSvgDialog, styles));

--- a/src/ExportAsUrlDialog.js
+++ b/src/ExportAsUrlDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import withRoot from './withRoot';
 import CloseIcon from '@mui/icons-material/Close';
 import LinkIcon from '@mui/icons-material/Link';
@@ -113,4 +113,4 @@ ExportAsUrlDialog.propTypes = {
   onClose: PropTypes.func.isRequired,
 };
 
-export default withRoot(withStyles(styles)(ExportAsUrlDialog));
+export default withRoot(withStyles(ExportAsUrlDialog, styles));

--- a/src/FormatDrawer.js
+++ b/src/FormatDrawer.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import withStyles from '@mui/styles/withStyles';
+import { useTheme } from '@mui/material/styles';
 import Drawer from '@mui/material/Drawer';
 import DialogTitle from '@mui/material/DialogTitle';
 import Divider from '@mui/material/Divider';
@@ -82,66 +84,52 @@ const edgeStyles = [
 
 const emptyColor = '';
 
-class FormatDrawer extends React.Component {
+const FormatDrawer = ({classes, type, defaultAttributes, onClick, onFormatDrawerClose, onStyleChange, onColorChange, onFillColorChange} ) => {
 
-  state = {
-    colorColorPickerIsOpen: false,
-    fillColorColorPickerIsOpen: false,
-  }
+  const [colorColorPickerIsOpen, setColorColorPickerIsOpen] = useState(false);
+  const [fillColorColorPickerIsOpen, setFillColorColorPickerIsOpen] = useState(false)
 
-  setColorColorPickerOpen = (open) => {
-    this.setState({
-      colorColorPickerIsOpen: open,
-    });
-  }
-
-  setFillColorColorPickerOpen = (open) => {
-    this.setState({
-      fillColorColorPickerIsOpen: open,
-    });
-  }
-
-  getStyleSet() {
-    if (this.props.defaultAttributes.style == null) {
+  function getStyleSet() {
+    if (defaultAttributes.style == null) {
       return new Set([]);
     } else {
-      let styleSet = new Set(this.props.defaultAttributes.style.split(', '))
+      let styleSet = new Set(defaultAttributes.style.split(', '))
       styleSet.add(emptyStyle);
       return styleSet;
     }
   }
 
-  setStyle(styleSet) {
+  function setStyle(styleSet) {
     if (styleSet.size === 0) {
-      this.props.onStyleChange(null);
+      onStyleChange(null);
     } else {
       styleSet.delete(emptyStyle);
-      this.props.onStyleChange([...styleSet].join(', '));
+      onStyleChange([...styleSet].join(', '));
     }
   }
 
-  handleClick = () => {
-    this.setColorColorPickerOpen(false);
-    this.setFillColorColorPickerOpen(false);
-    this.props.onClick();
+  const handleClick = () => {
+    setColorColorPickerIsOpen(false);
+    setFillColorColorPickerIsOpen(false);
+    onClick();
   };
 
-  handleDrawerClose = () => {
-    this.props.onFormatDrawerClose();
+  const handleDrawerClose = () => {
+    onFormatDrawerClose();
   };
 
-  handleStyleSwitchChange = (event) => {
-    let styleSet = this.getStyleSet();
+  const handleStyleSwitchChange = (event) => {
+    let styleSet = getStyleSet();
     styleSet.clear();
     if (event.target.checked) {
       styleSet.add(emptyStyle);
     }
-    this.setStyle(styleSet);
+    setStyle(styleSet);
   }
 
-  handleStyleChange = (styleName) => (event) => {
+  const handleStyleChange = (styleName) => (event) => {
     const checked = event.target.checked;
-    let styleSet = this.getStyleSet();
+    let styleSet = getStyleSet();
     if (checked) {
       styleSet.delete(emptyStyle);
       styleSet.add(styleName);
@@ -149,158 +137,153 @@ class FormatDrawer extends React.Component {
     else {
       styleSet.delete(styleName);
     }
-    this.setStyle(styleSet);
+    setStyle(styleSet);
   };
 
-  handleColorSwitchChange = (event) => {
+  const handleColorSwitchChange = (event) => {
     if (event.target.checked) {
-      this.props.onColorChange(emptyColor);
+      onColorChange(emptyColor);
     } else {
-      this.props.onColorChange(null);
+      onColorChange(null);
     }
   }
 
-  handleColorChange = (color) => {
-    this.props.onColorChange(color);
+  const handleColorChange = (color) => {
+    onColorChange(color);
   };
 
-  handleFillColorSwitchChange = (event) => {
+  const handleFillColorSwitchChange = (event) => {
     if (event.target.checked) {
-      this.props.onFillColorChange(emptyColor);
+      onFillColorChange(emptyColor);
     } else {
-      this.props.onFillColorChange(null);
+      onFillColorChange(null);
     }
   }
-  handleFillColorChange = (color) => {
-    this.props.onFillColorChange(color);
+  const handleFillColorChange = (color) => {
+    onFillColorChange(color);
   };
 
-  render() {
-    const { classes, theme } = this.props;
-    const { type } = this.props;
-
-    let styles = type === 'node' ? nodeStyles : edgeStyles;
-    let currentStyle = this.getStyleSet();
-    return (
-      <div className={classes.root}>
-        <Drawer
-          id="format-drawer"
-          variant="persistent"
-          anchor='left'
-          open
-          classes={{
-            paper: classes.drawerPaper,
-          }}
-          onClick={this.handleClick}
-        >
-          <div className={classes.drawerHeader}>
-            <DialogTitle id="form-dialog-title">
-              Default {this.props.type} attributes
-            </DialogTitle>
-            <IconButton id="close-button" onClick={this.handleDrawerClose} size="large">
-              {theme.direction === 'rtl' ? <ChevronRightIcon /> : <ChevronLeftIcon />}
-            </IconButton>
-          </div>
-          <Divider />
-          <FormControl variant="standard" className={classes.styleFormControl}>
-            <FormGroup row>
-              <FormControlLabel
-                className={classes.styleSwitch}
-                control={
-                  <Switch
-                    id="style-switch"
-                    checked={currentStyle.size !== 0}
-                    onChange={this.handleStyleSwitchChange}
-                  />
-                }
-                label="style"
-                labelPlacement="start"
-              />
-            </FormGroup>
-            <FormGroup row id="styles">
-              {styles.map((style) =>
-                <FormControlLabel
-                className={classes.styleCheckbox}
-                  control={
-                    <Checkbox
-                      id={style}
-                      checked={currentStyle.has(style)}
-                    onChange={this.handleStyleChange(style)}
-                    value={style}
-                    />
-                  }
-                  key={style}
-                  label={style}
+  let styles = type === 'node' ? nodeStyles : edgeStyles;
+  let currentStyle = getStyleSet();
+  const theme = useTheme();
+  return (
+    <div className={classes.root}>
+      <Drawer
+        id="format-drawer"
+        variant="persistent"
+        anchor='left'
+        open
+        classes={{
+          paper: classes.drawerPaper,
+        }}
+        onClick={handleClick}
+      >
+        <div className={classes.drawerHeader}>
+          <DialogTitle id="form-dialog-title">
+            Default {type} attributes
+          </DialogTitle>
+          <IconButton id="close-button" onClick={handleDrawerClose} size="large">
+            {theme.direction === 'rtl' ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+          </IconButton>
+        </div>
+        <Divider />
+        <FormControl variant="standard" className={classes.styleFormControl}>
+          <FormGroup row>
+            <FormControlLabel
+              className={classes.styleSwitch}
+              control={
+                <Switch
+                  id="style-switch"
+                  checked={currentStyle.size !== 0}
+                  onChange={handleStyleSwitchChange}
                 />
-              )}
-            </FormGroup>
-          </FormControl>
-          <FormControl
-            variant="standard"
-            className={classes.colorFormControl}
-            id="color-picker-form">
-            <FormGroup row>
+              }
+              label="style"
+              labelPlacement="start"
+            />
+          </FormGroup>
+          <FormGroup row id="styles">
+            {styles.map((style) =>
               <FormControlLabel
-                className={classes.colorSwitch}
+              className={classes.styleCheckbox}
                 control={
-                  <Switch
-                    id="color-switch"
-                    checked={this.props.defaultAttributes.color != null}
-                    onChange={this.handleColorSwitchChange}
+                  <Checkbox
+                    id={style}
+                    checked={currentStyle.has(style)}
+                  onChange={handleStyleChange(style)}
+                  value={style}
                   />
                 }
-                label="color"
-                labelPlacement="start"
+                key={style}
+                label={style}
               />
-            </FormGroup>
-            <FormGroup row>
-              <ColorPicker
-                id="color-picker"
-                open={this.state.colorColorPickerIsOpen}
-                setOpen={this.setColorColorPickerOpen}
-                invert={true}
-                color={this.props.defaultAttributes.color || ''}
-                onChange={color => this.handleColorChange(color)}
-              />
-            </FormGroup>
-          </FormControl>
-          <FormControl
-            variant="standard"
-            className={classes.colorFormControl}
-            id="fillcolor-picker-form">
-            <FormGroup row>
-              <FormControlLabel
-                className={classes.colorSwitch}
-                control={
-                  <Switch
-                    id="fillcolor-switch"
-                    checked={this.props.defaultAttributes.fillcolor != null}
-                    onChange={this.handleFillColorSwitchChange}
-                  />
-                }
-                label="fillcolor"
-                labelPlacement="start"
-              />
-            </FormGroup>
-            <FormGroup row>
-              <ColorPicker
-                id="fillcolor-picker"
-                open={this.state.fillColorColorPickerIsOpen}
-                setOpen={this.setFillColorColorPickerOpen}
-                color={this.props.defaultAttributes.fillcolor || ''}
-                onChange={color => this.handleFillColorChange(color)}
-              />
-            </FormGroup>
-          </FormControl>
-        </Drawer>
-      </div>
-    );
-  }
+            )}
+          </FormGroup>
+        </FormControl>
+        <FormControl
+          variant="standard"
+          className={classes.colorFormControl}
+          id="color-picker-form">
+          <FormGroup row>
+            <FormControlLabel
+              className={classes.colorSwitch}
+              control={
+                <Switch
+                  id="color-switch"
+                  checked={defaultAttributes.color != null}
+                  onChange={handleColorSwitchChange}
+                />
+              }
+              label="color"
+              labelPlacement="start"
+            />
+          </FormGroup>
+          <FormGroup row>
+            <ColorPicker
+              id="color-picker"
+              open={colorColorPickerIsOpen}
+              setOpen={setColorColorPickerIsOpen}
+              invert={true}
+              color={defaultAttributes.color || ''}
+              onChange={color => handleColorChange(color)}
+            />
+          </FormGroup>
+        </FormControl>
+        <FormControl
+          variant="standard"
+          className={classes.colorFormControl}
+          id="fillcolor-picker-form">
+          <FormGroup row>
+            <FormControlLabel
+              className={classes.colorSwitch}
+              control={
+                <Switch
+                  id="fillcolor-switch"
+                  checked={defaultAttributes.fillcolor != null}
+                  onChange={handleFillColorSwitchChange}
+                />
+              }
+              label="fillcolor"
+              labelPlacement="start"
+            />
+          </FormGroup>
+          <FormGroup row>
+            <ColorPicker
+              id="fillcolor-picker"
+              open={fillColorColorPickerIsOpen}
+              setOpen={setFillColorColorPickerIsOpen}
+              color={defaultAttributes.fillcolor || ''}
+              onChange={color => handleFillColorChange(color)}
+            />
+          </FormGroup>
+        </FormControl>
+      </Drawer>
+    </div>
+  );
 }
 
 FormatDrawer.propTypes = {
   classes: PropTypes.object.isRequired,
-  theme: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles, { withTheme: true })(FormatDrawer);
+export default withStyles(styles)(FormatDrawer);

--- a/src/FormatDrawer.js
+++ b/src/FormatDrawer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useState } from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import { useTheme } from '@mui/material/styles';
 import Drawer from '@mui/material/Drawer';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -286,4 +286,4 @@ FormatDrawer.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(FormatDrawer);
+export default withStyles(FormatDrawer, styles);

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import Fade from '@mui/material/Fade';
 import CircularProgress from '@mui/material/CircularProgress';
 import { select as d3_select} from 'd3-selection';
@@ -790,4 +790,4 @@ Graph.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(Graph);
+export default withStyles(Graph, styles);

--- a/src/InsertPanels.js
+++ b/src/InsertPanels.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
@@ -194,4 +194,4 @@ InsertPanels.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(InsertPanels);
+export default withStyles(InsertPanels, styles);

--- a/src/KeyboardShortcutsDialog.js
+++ b/src/KeyboardShortcutsDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import withRoot from './withRoot';
 import IconButton from '@mui/material/IconButton';
 import Dialog from '@mui/material/Dialog';
@@ -93,4 +93,4 @@ KeyboardShortcutsDialog.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withRoot(withStyles(styles)(KeyboardShortcutsDialog));
+export default withRoot(withStyles(KeyboardShortcutsDialog, styles));

--- a/src/MouseOperationsDialog.js
+++ b/src/MouseOperationsDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import withRoot from './withRoot';
 import IconButton from '@mui/material/IconButton';
 import Dialog from '@mui/material/Dialog';
@@ -89,4 +89,4 @@ MouseOperationsDialog.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withRoot(withStyles(styles)(MouseOperationsDialog));
+export default withRoot(withStyles(MouseOperationsDialog, styles));

--- a/src/OpenFromBrowserDialog.js
+++ b/src/OpenFromBrowserDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import withRoot from './withRoot';
 import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
@@ -305,4 +305,4 @@ OpenFromBrowserDialog.propTypes = {
   onOpen: PropTypes.func.isRequired,
 };
 
-export default withRoot(withStyles(styles)(OpenFromBrowserDialog));
+export default withRoot(withStyles(OpenFromBrowserDialog, styles));

--- a/src/SaveAsToBrowserDialog.js
+++ b/src/SaveAsToBrowserDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import withRoot from './withRoot';
 import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
@@ -141,4 +141,4 @@ SaveAsToBrowserDialog.propTypes = {
   projects: PropTypes.object.isRequired,
 };
 
-export default withRoot(withStyles(styles)(SaveAsToBrowserDialog));
+export default withRoot(withStyles(SaveAsToBrowserDialog, styles));

--- a/src/SettingsDialog.js
+++ b/src/SettingsDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import withRoot from './withRoot';
 import IconButton from '@mui/material/IconButton';
 import Dialog from '@mui/material/Dialog';
@@ -365,4 +365,4 @@ SettingsDialog.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withRoot(withStyles(styles)(SettingsDialog));
+export default withRoot(withStyles(SettingsDialog, styles));

--- a/src/SvgPreview.js
+++ b/src/SvgPreview.js
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import { useTheme } from '@mui/material/styles';
 
 const previewWidth = 400;
@@ -101,4 +101,4 @@ SvgPreview.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(SvgPreview);
+export default withStyles(SvgPreview, styles);

--- a/src/SvgPreview.js
+++ b/src/SvgPreview.js
@@ -1,8 +1,11 @@
 import React from 'react';
+import { useState } from 'react';
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import withStyles from '@mui/styles/withStyles';
+import { useTheme } from '@mui/material/styles';
 
 const previewWidth = 400;
 const previewHeight = 250;
@@ -22,86 +25,73 @@ const styles = theme => ({
   },
 });
 
-class SvgPreview extends React.Component {
+const SvgPreview = ({ classes, svg, width, height }) => {
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      preview: false,
-      x: 0,
-      y: 0,
-    };
-  }
+  const [preview, setPreview] = useState(false);
+  const [x, setX] = useState(0);
+  const [y, setY] = useState(0);
 
-  componentDidMount() {
-    this.componentDidUpdate();
-  }
+  let divPreview;
+  let divThumbnail;
 
-  componentDidUpdate() {
-    const svgThumbnail = this.divThumbnail.querySelector('svg');
+  useEffect(() => {
+    const svgThumbnail = divThumbnail.querySelector('svg');
     if (svgThumbnail) {
-      svgThumbnail.setAttribute('width', this.props.width);
-      svgThumbnail.setAttribute('height', this.props.height);
+      svgThumbnail.setAttribute('width', width);
+      svgThumbnail.setAttribute('height', height);
       const g = svgThumbnail.querySelector('g');
-      g.addEventListener('mouseenter', this.handleMouseEnter);
-      g.addEventListener('mouseleave', this.handleMouseOut);
+      g.addEventListener('mouseenter', handleMouseEnter);
+      g.addEventListener('mouseleave', handleMouseOut);
     }
-    if (this.divPreview) {
-      const svgPreview = this.divPreview.querySelector('svg');
+    if (divPreview) {
+      const svgPreview = divPreview.querySelector('svg');
       svgPreview.setAttribute('width', previewWidth);
       svgPreview.setAttribute('height', previewHeight);
     }
-  }
+  });
 
-  handleMouseEnter = (event) => {
-    this.setState({
-      preview: true,
-      x: event.clientX,
-      y: event.clientY,
-    });
-  }
+  const handleMouseEnter = (event) => {
+    setPreview(true);
+    setX(event.clientX);
+    setY(event.clientY);
+  };
 
-  handleMouseOut = (event) => {
-    this.setState({
-      preview: false,
-    });
-  }
+  const handleMouseOut = (event) => {
+    setPreview(false);
+  };
 
-  render() {
-    const { classes } = this.props;
-    const { theme } = this.props;
-    const previewMargin = +theme.spacing(previewMarginUnits).replace('px', '');
+  const theme = useTheme();
+  const previewMargin = +theme.spacing(previewMarginUnits).replace('px', '');
 
-    return (
-      <React.Fragment>
-        <div
-          id="svg-wrapper"
-          ref={div => this.divThumbnail = div}
-          dangerouslySetInnerHTML={{__html: this.props.svg}}
+  return (
+    <React.Fragment>
+      <div
+        id="svg-wrapper"
+        ref={div => divThumbnail = div}
+        dangerouslySetInnerHTML={{__html: svg}}
+      >
+      </div>
+      {preview &&
+        <Card
+          id="preview-pop-up"
+          className={classes.card}
+          raised
+          style={{
+            left: x + previewMargin,
+            top: y + previewMargin,
+          }}
         >
-        </div>
-        {this.state.preview &&
-          <Card
-            id="preview-pop-up"
-            className={classes.card}
-            raised
-            style={{
-              left: this.state.x + previewMargin,
-              top: this.state.y + previewMargin,
-            }}
-          >
-            <CardContent className={classes.cardContent}>
-              <div
-                ref={div => this.divPreview = div}
-                dangerouslySetInnerHTML={{__html: this.props.svg}}
-              >
-              </div>
-            </CardContent>
-          </Card>
-        }
-      </React.Fragment>
-    );
-  }
+          <CardContent className={classes.cardContent}>
+            <div
+              ref={div => divPreview = div}
+              dangerouslySetInnerHTML={{__html: svg}}
+            >
+            </div>
+          </CardContent>
+        </Card>
+      }
+    </React.Fragment>
+  );
 }
 
 SvgPreview.propTypes = {
@@ -109,7 +99,6 @@ SvgPreview.propTypes = {
   width: PropTypes.string.isRequired,
   height: PropTypes.string.isRequired,
   classes: PropTypes.object.isRequired,
-  theme: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles, { withTheme: true })(SvgPreview);
+export default withStyles(styles)(SvgPreview);

--- a/src/TextEditor.js
+++ b/src/TextEditor.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import AceEditor from 'react-ace';
 import 'ace-builds/src-noconflict/mode-dot';
 import 'ace-builds/src-noconflict/theme-github';
@@ -160,4 +160,4 @@ class TextEditor extends React.Component {
   }
 }
 
-export default withStyles(styles)(TextEditor);
+export default withStyles(TextEditor, styles);

--- a/src/UpdatedSnackbar.js
+++ b/src/UpdatedSnackbar.js
@@ -4,7 +4,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
 import Snackbar from '@mui/material/Snackbar';
 import SnackbarContent from '@mui/material/SnackbarContent';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import withRoot from './withRoot';
 import packageJSON from '../package.json';
 import versions from './versions.json';
@@ -107,4 +107,4 @@ UpdatedSnackbar.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withRoot(withStyles(styles)(UpdatedSnackbar));
+export default withRoot(withStyles(UpdatedSnackbar, styles));

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,7 +3,7 @@ import 'typeface-roboto';
 import PropTypes from 'prop-types';
 import Paper from '@mui/material/Paper';
 import Grid from '@mui/material/Grid';
-import withStyles from '@mui/styles/withStyles';
+import { withStyles } from 'tss-react/mui';
 import withRoot from '../withRoot';
 import ButtonAppBar from '../ButtonAppBar';
 import Graph from '../Graph';
@@ -939,4 +939,4 @@ Index.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withRoot(withStyles(styles)(Index));
+export default withRoot(withStyles(Index, styles));

--- a/src/withRoot.js
+++ b/src/withRoot.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ThemeProvider, StyledEngineProvider, createTheme, adaptV4Theme } from '@mui/material/styles';
+import { ThemeProvider, StyledEngineProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 
 // A theme with custom primary and secondary color.


### PR DESCRIPTION
See https://mui.com/material-ui/migration/migrating-from-jss/ for details. This uses the second option, see https://mui.com/material-ui/migration/migrating-from-jss/#2-use-tss-react.

@mui/styles, the old JSS based styling solution, was deprecated with the release of MUI Core v5 in late 2021. It depended on [JSS](https://cssinjs.org/) as a styling solution, which is no longer used in @mui/material.

@mui/styles is not compatible with [React.StrictMode](https://react.dev/reference/react/StrictMode) or React 18, and it will not be updated.

See https://mui.com/system/styles/basics/.