### PR TITLE
Fix layout of nodes in insert nodes panel by adding 'display: flex'

### DIFF
--- a/src/InsertPanels.js
+++ b/src/InsertPanels.js
@@ -114,6 +114,7 @@ const styles = theme => ({
     flexShrink: 0,
   },
   columns: {
+    display: 'flex',
     flexWrap: 'wrap',
     alignItems: 'flex-start',
   },


### PR DESCRIPTION
This was an inadvertent consequence of
2ca5a6ab4c58927605e95740c51f2aefc0d5d932 and was due to that the replaced 'Accordion' component did set "display: 'flex'", while its replacement, 'ExpansionPanelSummary', sets 'display: block' instead. See
https://mui.com/material-ui/migration/v5-component-changes/#remove-display-flex.