### PR TITLE
fix focus removed from the graph when the ctrl key clicked in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Lost characters when typing fast and DOT parsing errors occur #236
 * New nodes created after linking nodes with a space in the label #215 (thanks @ygra)
+* Keyboard shortcuts involving the control key in the graph doesn't work in Firefox on Ubuntu when the "Locate Pointer" feature is enabled #260
 
 ## [0.6.5] - 2022-02-24
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -120,10 +120,21 @@ class Index extends React.Component {
       }
       window.history.replaceState(null, null, window.location.pathname);
     }
+
+    document.documentElement.addEventListener('mouseleave', () => {
+      this.outsideOfDocument = true;
+    });
+
+    document.documentElement.addEventListener('mouseenter', () => {
+      this.outsideOfDocument = false;
+    })
+
     document.onblur = () => {
       // Needed when the user clicks outside the document,
       // e.g. the browser address bar
-      this.setFocus(null);
+      if (this.outsideOfDocument) {
+        this.setFocus(null);
+      }
     }
   }
 


### PR DESCRIPTION
This fixes
https://github.com/magjac/graphviz-visual-editor/issues/260.