### PR TITLE
Fix undo history is reset when opening graph in fullscreen mode

### DIFF
--- a/cypress/e2e/fullscreen_graph.spec.js
+++ b/cypress/e2e/fullscreen_graph.spec.js
@@ -17,19 +17,19 @@ describe('Show graph only mode', function () {
     cy.nodes().should('have.length', 2);
     cy.edges().should('have.length', 1);
 
-    cy.textEditorWrapper().should('exist');
+    cy.textEditorWrapper().should('be.visible');
     cy.toolbar().should('exist');
     cy.canvas().invoke('width').should('be.lt', viewportWidth / 2)
 
     cy.fullscreenButton().click();
 
-    cy.textEditorWrapper().should('not.exist');
+    cy.textEditorWrapper().should('not.be.visible');
     cy.toolbar().should('not.exist');
     cy.canvas().invoke('width').should('be.eq', viewportWidth)
 
     cy.fullscreenButton().click();
 
-    cy.textEditorWrapper().should('exist');
+    cy.textEditorWrapper().should('be.visible');
     cy.toolbar().should('exist');
     cy.canvas().invoke('width').should('be.lt', viewportWidth / 2)
   });
@@ -49,20 +49,20 @@ describe('Show graph only mode', function () {
     cy.nodes().should('have.length', 2);
     cy.edges().should('have.length', 1);
 
-    cy.textEditorWrapper().should('exist');
+    cy.textEditorWrapper().should('be.visible');
     cy.toolbar().should('exist');
     cy.canvas().invoke('width').should('be.lt', viewportWidth / 2)
 
     cy.canvas().click();
     cy.get('body').type('f');
 
-    cy.textEditorWrapper().should('not.exist');
+    cy.textEditorWrapper().should('not.be.visible');
     cy.toolbar().should('not.exist');
     cy.canvas().invoke('width').should('be.eq', viewportWidth)
 
     cy.get('body').type('f');
 
-    cy.textEditorWrapper().should('exist');
+    cy.textEditorWrapper().should('be.visible');
     cy.toolbar().should('exist');
     cy.canvas().invoke('width').should('be.lt', viewportWidth / 2)
   });

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -855,53 +855,51 @@ class Index extends React.Component {
             width: '100%',
           }}
         >
-          {!this.state.fullscreen &&
-            <Grid item xs={columns.textEditor} padding={1.5}>
-              <Paper elevation={leftPaneElevation} className={paperClass}>
-                {this.state.nodeFormatDrawerIsOpen &&
-                  <FormatDrawer
-                    type='node'
-                    defaultAttributes={this.state.defaultNodeAttributes}
-                    onClick={this.handleNodeFormatDrawerClick}
-                    onFormatDrawerClose={this.handleNodeFormatDrawerClose}
-                    onStyleChange={this.handleNodeStyleChange}
-                    onColorChange={this.handleNodeColorChange}
-                    onFillColorChange={this.handleNodeFillColorChange}
-                  />
-                }
-                {this.state.edgeFormatDrawerIsOpen &&
-                  <FormatDrawer
-                    type='edge'
-                    defaultAttributes={this.state.defaultEdgeAttributes}
-                    onClick={this.handleEdgeFormatDrawerClick}
-                    onFormatDrawerClose={this.handleEdgeFormatDrawerClose}
-                    onStyleChange={this.handleEdgeStyleChange}
-                    onColorChange={this.handleEdgeColorChange}
-                    onFillColorChange={this.handleEdgeFillColorChange}
-                  />
-                }
-                <div style={{display: editorIsOpen ? 'block' : 'none'}}>
-                  <TextEditor
-                    // allocated viewport width - 2 * padding
-                    width={`calc(${columns.textEditor * 100 / 12}vw - 2 * 12px)`}
-                    height={`calc(100vh - 64px - 2 * 12px - ${this.updatedSnackbarIsOpen ? "64px" : "0px"})`}
-                    dotSrc={this.state.forceNewDotSrc ? this.state.dotSrc : null}
-                    onTextChange={this.handleTextChange}
-                    onFocus={this.handleTextEditorFocus}
-                    onBlur={this.handleTextEditorBlur}
-                    error={this.state.error}
-                    selectedGraphComponents={this.state.selectedGraphComponents}
-                    holdOff={this.state.holdOff}
-                    fontSize={this.state.fontSize}
-                    tabSize={this.state.tabSize}
-                    registerUndo={this.registerUndo}
-                    registerRedo={this.registerRedo}
-                    registerUndoReset={this.registerUndoReset}
-                  />
-                </div>
-              </Paper>
-            </Grid>
-          }
+          <Grid item xs={columns.textEditor} padding={1.5} style={{ display: this.state.fullscreen ? 'none' : 'block' }}>
+            <Paper elevation={leftPaneElevation} className={paperClass}>
+              {this.state.nodeFormatDrawerIsOpen &&
+                <FormatDrawer
+                  type='node'
+                  defaultAttributes={this.state.defaultNodeAttributes}
+                  onClick={this.handleNodeFormatDrawerClick}
+                  onFormatDrawerClose={this.handleNodeFormatDrawerClose}
+                  onStyleChange={this.handleNodeStyleChange}
+                  onColorChange={this.handleNodeColorChange}
+                  onFillColorChange={this.handleNodeFillColorChange}
+                />
+              }
+              {this.state.edgeFormatDrawerIsOpen &&
+                <FormatDrawer
+                  type='edge'
+                  defaultAttributes={this.state.defaultEdgeAttributes}
+                  onClick={this.handleEdgeFormatDrawerClick}
+                  onFormatDrawerClose={this.handleEdgeFormatDrawerClose}
+                  onStyleChange={this.handleEdgeStyleChange}
+                  onColorChange={this.handleEdgeColorChange}
+                  onFillColorChange={this.handleEdgeFillColorChange}
+                />
+              }
+              <div style={{display: editorIsOpen ? 'block' : 'none'}}>
+                <TextEditor
+                  // allocated viewport width - 2 * padding
+                  width={`calc(${columns.textEditor * 100 / 12}vw - 2 * 12px)`}
+                  height={`calc(100vh - 64px - 2 * 12px - ${this.updatedSnackbarIsOpen ? "64px" : "0px"})`}
+                  dotSrc={this.state.forceNewDotSrc ? this.state.dotSrc : null}
+                  onTextChange={this.handleTextChange}
+                  onFocus={this.handleTextEditorFocus}
+                  onBlur={this.handleTextEditorBlur}
+                  error={this.state.error}
+                  selectedGraphComponents={this.state.selectedGraphComponents}
+                  holdOff={this.state.holdOff}
+                  fontSize={this.state.fontSize}
+                  tabSize={this.state.tabSize}
+                  registerUndo={this.registerUndo}
+                  registerRedo={this.registerRedo}
+                  registerUndoReset={this.registerUndoReset}
+                />
+              </div>
+            </Paper>
+          </Grid>
           {this.state.insertPanelsAreOpen && this.state.graphInitialized && !this.state.fullscreen && (
             <Grid item xs={columns.insertPanels} padding={1.5}>
               <Paper elevation={midPaneElevation} className={paperClass}>


### PR DESCRIPTION
Instead of removing the left pane including the editor in fullscreen mode, just hide it.