### PR TITLE
Upgrade itegration-test Docker image in CircleCI to Nodej.s version 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run: make && yarn test:coverage && yarn run codecov
   integration-test:
     docker:
-      - image: cypress/browsers:node-16.18.1-chrome-109.0.5414.74-1-ff-109.0-edge-109.0.1518.52-1
+      - image: cypress/browsers:node-18.16.1-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1
         environment:
           ## this enables colors in the output
           TERM: xterm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,15 @@ jobs:
           paths:
             - ~/.npm
             - ~/.cache
-      - run: apt update && apt install make && make && npm run start:coverage & $(npm bin)/wait-on http://localhost:3000/ && npm run integration-test && yarn run codecov
+      - run:
+          command: |
+            apt update
+            apt install make
+            make
+            npm run start:coverage &
+            $(npm bin)/wait-on http://localhost:3000/
+            npm run integration-test
+            yarn run codecov
 workflows:
   version: 2
   build-and-integration-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
             apt install make
             make
             npm run start:coverage &
-            $(npm bin)/wait-on http://localhost:3000/
+            npm exec wait-on http://localhost:3000/
             npm run integration-test
             yarn run codecov
 workflows:


### PR DESCRIPTION
This avoids this problem i CircleCI:
    
    Err:5 https://dl.google.com/linux/chrome/deb stable InRelease
      The following signatures couldn't be verified because the public key is not available: NO_PUBKEY E88979FB9B30ACF2
    ...
    W: GPG error: https://dl.google.com/linux/chrome/deb stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY E88979FB9B30ACF2
    E: The repository 'https://dl.google.com/linux/chrome/deb stable InRelease' is not signed.
