### PR TITLE
Fix handling of nodes with names equal to properties of the JavaScript Object type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ through
 version
 [5.3.0](https://github.com/magjac/d3-graphviz/blob/master/CHANGELOG.md#530--2024-02-11).
 
+### Fixed
+* Entering a node named 'constructor' causes error and no graph rendered #265
+* Having a node called toString hard crashes the editor #272
+
 ## [1.0.0] - 2024-01-21
 
 ### Added

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -68,7 +68,7 @@ class Graph extends React.Component {
     this.latestEdgeAttributes = {
     }
     // latestInsertedNodeShape is not necessarily the same as
-    // latestNodeAttributes.shape with is also set on node copy
+    // latestNodeAttributes.shape which is also set on node copy
     this.latestInsertedNodeShape = null;
     this.drawnNodeName = null;
     this.nodeIndex = null;

--- a/src/dot.js
+++ b/src/dot.js
@@ -77,7 +77,7 @@ export default class DotGraph {
       }
       else if (child.type === 'node_id') {
         const nodeId = child.id;
-        if (this.nodes[nodeId] == null) {
+        if (!Object.hasOwn(this.nodes, nodeId)) {
           this.nodes[nodeId] = {
             locations: [],
             attributes: {},

--- a/src/dot.test.js
+++ b/src/dot.test.js
@@ -129,6 +129,12 @@ class WrapDot extends React.Component {
   }
 };
 
+function getAllPropertyNames(obj) {
+  const proto     = Object.getPrototypeOf(obj);
+  const inherited = (proto) ? getAllPropertyNames(proto) : [];
+  return [...new Set(Object.getOwnPropertyNames(obj).concat(inherited))];
+}
+
 let console_error = console.error;
 
 afterEach(() => console.error = console_error);
@@ -231,6 +237,13 @@ describe('dot.DotGraph.toString()', () => {
 
   it('renders a single node with a port and compass point', () => {
     let dotSrc = 'digraph {a:p1:n}';
+    render(<WrapDot dotSrc={dotSrc} />);
+    expect(screen.getByTestId('dot-src').textContent).toBe(dotSrc);
+  });
+
+  it('renders nodes with names equal to properties of the Javascript Object', () => {
+    const nodeNames = getAllPropertyNames({});
+    const dotSrc = `digraph {${nodeNames.join(' ')}}`;
     render(<WrapDot dotSrc={dotSrc} />);
     expect(screen.getByTestId('dot-src').textContent).toBe(dotSrc);
   });


### PR DESCRIPTION
Fixes https://github.com/magjac/graphviz-visual-editor/issues/265 and https://github.com/magjac/graphviz-visual-editor/issues/272.
