### PR TITLE
Grammar: Add 'c' to compass point values

### DIFF
--- a/src/dot.test.js
+++ b/src/dot.test.js
@@ -241,6 +241,12 @@ describe('dot.DotGraph.toString()', () => {
     expect(screen.getByTestId('dot-src').textContent).toBe(dotSrc);
   });
 
+  it('accepts "c" as a compass point on nodes', () => {
+    let dotSrc = 'digraph {a:p1:c}';
+    render(<WrapDot dotSrc={dotSrc} />);
+    expect(screen.getByTestId('dot-src').textContent).toBe(dotSrc);
+  });
+
   it('renders nodes with names equal to properties of the Javascript Object', () => {
     const nodeNames = getAllPropertyNames({});
     const dotSrc = `digraph {${nodeNames.join(' ')}}`;
@@ -282,6 +288,12 @@ describe('dot.DotGraph.toString()', () => {
 
   it('renders an edge between ports and compass points on two nodes in a directed graph', () => {
     let dotSrc = 'digraph {a:p1:n -> b:p2:e}';
+    render(<WrapDot dotSrc={dotSrc} />);
+    expect(screen.getByTestId('dot-src').textContent).toBe(dotSrc);
+  });
+
+  it('renders an edge directed at the center point of two nodes', () => {
+    let dotSrc = 'digraph {a:p1:c -> b:p2:c}';
     render(<WrapDot dotSrc={dotSrc} />);
     expect(screen.getByTestId('dot-src').textContent).toBe(dotSrc);
   });

--- a/src/dotGrammar.pegjs
+++ b/src/dotGrammar.pegjs
@@ -151,7 +151,7 @@ subgraph
       }
 
 compass_pt
-  = 'n'/'ne'/'e'/'se'/'s'/'sw'/'w'/'nw'
+  = 'n'/'ne'/'e'/'se'/'s'/'sw'/'w'/'nw'/'c'
 
 ID
   = STRING


### PR DESCRIPTION
Fixes #307

The grammar also lists `_` in the list of values, but I can't tell if that's a literal underscore or some sort of placeholder, because a note just below also says this:

> Note also that the allowed compass point values are not keywords, so these strings can be used elsewhere as ordinary identifiers and, conversely, the parser will actually accept any identifier.

**Edit:** Added some tests, as well. Confirmed that they pass on the branch, but fail if I manually revert 56059ae.